### PR TITLE
Close the DirectoryStream after use

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,5 @@
+Version 1.4 - Close the DirectoryStream after reuse to avoid resource leak
+
 Version 1.3 - Switch from Files.listFiles to Files.newDirectoryStream for better performance over network mounted drives
 
 Version 1.2 - Add support for Preservica style multi-character subdirs


### PR DESCRIPTION
Tje [Java 8 JavaDoc for DirectoryStream](https://docs.oracle.com/javase/8/docs/api/java/nio/file/DirectoryStream.html) is pretty explicit: _Failure to close the stream may result in a resource leak._. I just need to remember to actually read the Javadoc.

This pull requests closes the stream after use.